### PR TITLE
Add rocket fins airframe example

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/14002_rocket_fins
+++ b/ROMFS/px4fmu_common/init.d/airframes/14002_rocket_fins
@@ -1,0 +1,36 @@
+#!/bin/sh
+#
+# @name Rocket with Fins
+#
+# @type Rocket
+# @class Rocket
+#
+# @maintainer Lorenz Meier <lorenz@px4.io>
+#
+
+. ${R}etc/init.d/rc.mc_defaults
+
+# Parameters
+param set-default PWM_MAIN_RATE 400
+param set-default IMU_INTEG_RATE 8000
+
+# Use custom mixer
+set MIXER rocket_fins.main.mix
+
+# Airframe parameter defaults version
+set PARAM_DEFAULTS_VER 1
+
+# Square quadrotor X PX4 numbering
+param set-default CA_ROTOR_COUNT 4
+param set-default CA_ROTOR0_PX 1
+param set-default CA_ROTOR0_PY 1
+param set-default CA_ROTOR1_PX -1
+param set-default CA_ROTOR1_PY -1
+param set-default CA_ROTOR2_PX 1
+param set-default CA_ROTOR2_PY -1
+param set-default CA_ROTOR2_KM -0.05
+param set-default CA_ROTOR3_PX -1
+param set-default CA_ROTOR3_PY 1
+param set-default CA_ROTOR3_KM -0.05
+
+# TODO: start rocket-specific modules

--- a/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
+++ b/ROMFS/px4fmu_common/init.d/airframes/CMakeLists.txt
@@ -96,7 +96,8 @@ if(CONFIG_MODULES_MC_RATE_CONTROL)
 		12001_octo_cox
 
 		# [14000, 14999] MC with tilt
-		14001_generic_mc_with_tilt
+                14001_generic_mc_with_tilt
+                14002_rocket_fins
 
 		16001_helicopter
 

--- a/ROMFS/px4fmu_common/mixers/rocket_fins.main.mix
+++ b/ROMFS/px4fmu_common/mixers/rocket_fins.main.mix
@@ -1,0 +1,2 @@
+# Placeholder mixer for rocket fins
+


### PR DESCRIPTION
## Summary
- add `rocket_fins.main.mix` placeholder
- create `14002_rocket_fins` airframe startup script
- register the new airframe ID in CMakeLists

## Testing
- `make check` *(fails: kconfiglib missing)*