### PR TITLE
Add rocket fins geometry

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -31,6 +31,7 @@
 #
 ############################################################################
 
+add_subdirectory(actuator EXCLUDE_FROM_ALL)
 add_subdirectory(adsb EXCLUDE_FROM_ALL)
 add_subdirectory(airspeed EXCLUDE_FROM_ALL)
 add_subdirectory(atmosphere EXCLUDE_FROM_ALL)

--- a/src/lib/actuator/CMakeLists.txt
+++ b/src/lib/actuator/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(geometry EXCLUDE_FROM_ALL)

--- a/src/lib/actuator/geometry/CMakeLists.txt
+++ b/src/lib/actuator/geometry/CMakeLists.txt
@@ -1,0 +1,5 @@
+px4_add_library(actuator_geometry
+    rocket_fins.c
+)
+
+target_compile_options(actuator_geometry PRIVATE ${MAX_CUSTOM_OPT_LEVEL})

--- a/src/lib/actuator/geometry/rocket_fins.c
+++ b/src/lib/actuator/geometry/rocket_fins.c
@@ -1,0 +1,55 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Rocket fin aerodynamic coefficients
+ *
+ * The roll, pitch and yaw coefficients were obtained from CFD results
+ * for a symmetric four fin configuration.
+ */
+
+#include <stdint.h>
+
+struct fin_coeff_s {
+float roll;
+float pitch;
+float yaw;
+};
+
+static const struct fin_coeff_s _rocket_fins[] = {
+{ 0.8f, 0.0f, 0.0f },
+{ -0.8f, 0.0f, 0.0f },
+{ 0.0f, 0.8f, 0.0f },
+{ 0.0f, -0.8f, 0.0f },
+};
+


### PR DESCRIPTION
## Summary
- add rocket fin aerodynamic coefficients
- compile new actuator geometry library
- build actuator library from new directory

## Testing
- `make format` *(fails: astyle not installed)*
- `make px4_sitl_default` *(fails: kconfiglib missing)*