### PR TITLE
Add rover mecanum msgs

### DIFF
--- a/msg/Buffer128.msg
+++ b/msg/Buffer128.msg
@@ -1,0 +1,6 @@
+uint64 timestamp                # time since system start (microseconds)
+
+uint8 len                       # length of data
+uint32 MAX_BUFLEN = 128
+
+uint8[128] data                 # data

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -46,9 +46,10 @@ set(msg_files
 	AdcReport.msg
 	Airspeed.msg
 	AirspeedWind.msg
-	AutotuneAttitudeControlStatus.msg
-	ButtonEvent.msg
-	CameraCapture.msg
+        AutotuneAttitudeControlStatus.msg
+        ButtonEvent.msg
+        Buffer128.msg
+        CameraCapture.msg
 	CameraStatus.msg
 	CameraTrigger.msg
 	CanInterfaceStatus.msg
@@ -171,9 +172,12 @@ set(msg_files
 	RateCtrlStatus.msg
 	RcChannels.msg
 	RcParameterMap.msg
-	RoverAttitudeSetpoint.msg
-	RoverAttitudeStatus.msg
-	RoverPositionSetpoint.msg
+        RoverAttitudeSetpoint.msg
+        RoverAttitudeStatus.msg
+        RoverMecanumGuidanceStatus.msg
+        RoverMecanumSetpoint.msg
+        RoverMecanumStatus.msg
+        RoverPositionSetpoint.msg
 	RoverRateSetpoint.msg
 	RoverRateStatus.msg
 	RoverSteeringSetpoint.msg

--- a/msg/RoverMecanumGuidanceStatus.msg
+++ b/msg/RoverMecanumGuidanceStatus.msg
@@ -1,0 +1,5 @@
+uint64 timestamp # time since system start (microseconds)
+
+float32 lookahead_distance # [m] Lookahead distance of the pure pursuit controller
+float32 heading_error      # [rad] Heading error of the pure pursuit controller
+float32 desired_speed      # [m/s] Desired velocity magnitude (speed)

--- a/msg/RoverMecanumSetpoint.msg
+++ b/msg/RoverMecanumSetpoint.msg
@@ -1,0 +1,9 @@
+uint64 timestamp # time since system start (microseconds)
+
+float32 forward_speed_setpoint            # [m/s] Desired forward speed
+float32 forward_speed_setpoint_normalized # [-1, 1] Desired normalized forward speed
+float32 lateral_speed_setpoint            # [m/s] Desired lateral speed
+float32 lateral_speed_setpoint_normalized # [-1, 1] Desired normalized lateral speed
+float32 yaw_rate_setpoint                 # [rad/s] Desired yaw rate
+float32 speed_diff_setpoint_normalized    # [-1, 1] Normalized speed difference between the left and right wheels
+float32 yaw_setpoint                      # [rad] Desired yaw (heading)

--- a/msg/RoverMecanumStatus.msg
+++ b/msg/RoverMecanumStatus.msg
@@ -1,0 +1,15 @@
+uint64 timestamp # time since system start (microseconds)
+
+float32 measured_forward_speed          # [m/s] Measured speed in body x direction. Positiv: forwards, Negativ: backwards
+float32 adjusted_forward_speed_setpoint # [m/s] Speed setpoint after applying slew rate
+float32 measured_lateral_speed          # [m/s] Measured speed in body y direction. Positiv: right, Negativ: left
+float32 adjusted_lateral_speed_setpoint # [m/s] Speed setpoint after applying slew rate
+float32 measured_yaw_rate               # [rad/s] Measured yaw rate
+float32 clyaw_yaw_rate_setpoint         # [rad/s] Yaw rate setpoint output by the closed loop yaw controller
+float32 adjusted_yaw_rate_setpoint      # [rad/s] Yaw rate setpoint from the closed loop yaw controller
+float32 measured_yaw                    # [rad] Measured yaw
+float32 adjusted_yaw_setpoint           # [rad] Yaw setpoint after applying slew rate
+float32 pid_yaw_rate_integral           # Integral of the PID for the closed loop yaw rate controller
+float32 pid_yaw_integral                # Integral of the PID for the closed loop yaw controller
+float32 pid_forward_throttle_integral   # Integral of the PID for the closed loop forward speed controller
+float32 pid_lateral_throttle_integral   # Integral of the PID for the closed loop lateral speed controller


### PR DESCRIPTION
## Summary
- add Buffer128.msg
- add RoverMecanum* messages for mecanum rover control
- integrate new messages in msg/CMakeLists

## Testing
- `make px4_sitl_default uorb_headers` *(fails: ModuleNotFoundError: No module named 'menuconfig')*