### PR TITLE
Add parameter files for rover modules

### DIFF
--- a/src/modules/payload_deliverer/CMakeLists.txt
+++ b/src/modules/payload_deliverer/CMakeLists.txt
@@ -33,11 +33,12 @@
 px4_add_module(
 	MODULE modules__payload_deliverer
 	MAIN payload_deliverer
-	SRCS
-		payload_deliverer.cpp
-		gripper.cpp
-	MODULE_CONFIG
-		module.yaml
+        SRCS
+                payload_deliverer.cpp
+                gripper.cpp
+                payload_deliverer_params.c
+        MODULE_CONFIG
+                module.yaml
 	COMPILE_FLAGS
 		#-DDEBUG_BUILD
 	DEPENDS

--- a/src/modules/payload_deliverer/payload_deliverer_params.c
+++ b/src/modules/payload_deliverer/payload_deliverer_params.c
@@ -1,0 +1,65 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file payload_deliverer_params.c
+ *
+ * Parameters defined by the Payload Deliverer module.
+ */
+
+/**
+ * Enable gripper actuation
+ *
+ * @min 0
+ * @max 1
+ * @group Payload Deliverer
+ */
+PARAM_DEFINE_INT32(PD_GRIPPER_EN, 0);
+
+/**
+ * Gripper type
+ *
+ * @min -1
+ * @max 0
+ * @group Payload Deliverer
+ */
+PARAM_DEFINE_INT32(PD_GRIPPER_TYPE, 0);
+
+/**
+ * Gripper timeout
+ *
+ * @unit s
+ * @min 0
+ * @group Payload Deliverer
+ */
+PARAM_DEFINE_FLOAT(PD_GRIPPER_TO, 3.0f);
+

--- a/src/modules/rover_ackermann/CMakeLists.txt
+++ b/src/modules/rover_ackermann/CMakeLists.txt
@@ -39,11 +39,12 @@ add_subdirectory(AckermannPosControl)
 px4_add_module(
 	MODULE modules__rover_ackermann
 	MAIN rover_ackermann
-	SRCS
-		RoverAckermann.cpp
-		RoverAckermann.hpp
-	DEPENDS
-		AckermannRateControl
+        SRCS
+                RoverAckermann.cpp
+                RoverAckermann.hpp
+                rover_ackermann_params.c
+        DEPENDS
+                AckermannRateControl
 		AckermannAttControl
 		AckermannVelControl
 		AckermannPosControl

--- a/src/modules/rover_ackermann/rover_ackermann_params.c
+++ b/src/modules/rover_ackermann/rover_ackermann_params.c
@@ -1,0 +1,82 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file rover_ackermann_params.c
+ *
+ * Parameters defined by the Rover Ackermann module.
+ */
+
+/**
+ * Wheel base
+ *
+ * @unit m
+ * @min 0
+ * @group Rover Ackermann
+ */
+PARAM_DEFINE_FLOAT(RA_WHEEL_BASE, 0.0f);
+
+/**
+ * Maximum steering angle
+ *
+ * @unit rad
+ * @min 0
+ * @group Rover Ackermann
+ */
+PARAM_DEFINE_FLOAT(RA_MAX_STR_ANG, 0.0f);
+
+/**
+ * Steering rate limit
+ *
+ * @unit deg/s
+ * @min -1
+ * @group Rover Ackermann
+ */
+PARAM_DEFINE_FLOAT(RA_STR_RATE_LIM, -1.0f);
+
+/**
+ * Acceptance radius maximum
+ *
+ * @unit m
+ * @min -1
+ * @group Rover Ackermann
+ */
+PARAM_DEFINE_FLOAT(RA_ACC_RAD_MAX, -1.0f);
+
+/**
+ * Acceptance radius gain
+ *
+ * @min 1
+ * @group Rover Ackermann
+ */
+PARAM_DEFINE_FLOAT(RA_ACC_RAD_GAIN, 1.0f);
+

--- a/src/modules/rover_differential/CMakeLists.txt
+++ b/src/modules/rover_differential/CMakeLists.txt
@@ -39,11 +39,12 @@ add_subdirectory(DifferentialPosControl)
 px4_add_module(
 	MODULE modules__rover_differential
 	MAIN rover_differential
-	SRCS
-		RoverDifferential.cpp
-		RoverDifferential.hpp
-	DEPENDS
-		DifferentialRateControl
+        SRCS
+                RoverDifferential.cpp
+                RoverDifferential.hpp
+                rover_differential_params.c
+        DEPENDS
+                DifferentialRateControl
 		DifferentialAttControl
 		DifferentialVelControl
 		DifferentialPosControl

--- a/src/modules/rover_differential/rover_differential_params.c
+++ b/src/modules/rover_differential/rover_differential_params.c
@@ -1,0 +1,82 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file rover_differential_params.c
+ *
+ * Parameters defined by the Rover Differential module.
+ */
+
+/**
+ * Wheel track
+ *
+ * @unit m
+ * @min 0
+ * @group Rover Differential
+ */
+PARAM_DEFINE_FLOAT(RD_WHEEL_TRACK, 0.0f);
+
+/**
+ * Max yaw rate at max throttle
+ *
+ * @unit m/s
+ * @min 0
+ * @group Rover Differential
+ */
+PARAM_DEFINE_FLOAT(RD_MAX_THR_YAW_R, 0.0f);
+
+/**
+ * Transition turn-drive threshold
+ *
+ * @unit rad
+ * @min 0
+ * @group Rover Differential
+ */
+PARAM_DEFINE_FLOAT(RD_TRANS_TRN_DRV, 0.0872665f);
+
+/**
+ * Transition drive-turn threshold
+ *
+ * @unit rad
+ * @min 0
+ * @group Rover Differential
+ */
+PARAM_DEFINE_FLOAT(RD_TRANS_DRV_TRN, 0.174533f);
+
+/**
+ * Mission speed gain
+ *
+ * @min -1
+ * @group Rover Differential
+ */
+PARAM_DEFINE_FLOAT(RD_MISS_SPD_GAIN, -1.0f);
+

--- a/src/modules/rover_mecanum/CMakeLists.txt
+++ b/src/modules/rover_mecanum/CMakeLists.txt
@@ -39,11 +39,12 @@ add_subdirectory(MecanumPosControl)
 px4_add_module(
 	MODULE modules__rover_mecanum
 	MAIN rover_mecanum
-	SRCS
-		RoverMecanum.cpp
-		RoverMecanum.hpp
-	DEPENDS
-		MecanumRateControl
+        SRCS
+                RoverMecanum.cpp
+                RoverMecanum.hpp
+                rover_mecanum_params.c
+        DEPENDS
+                MecanumRateControl
 		MecanumAttControl
 		MecanumVelControl
 		MecanumPosControl

--- a/src/modules/rover_mecanum/rover_mecanum_params.c
+++ b/src/modules/rover_mecanum/rover_mecanum_params.c
@@ -1,0 +1,73 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2025 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+/**
+ * @file rover_mecanum_params.c
+ *
+ * Parameters defined by the Rover Mecanum module.
+ */
+
+/**
+ * Wheel track
+ *
+ * @unit m
+ * @min 0
+ * @group Rover Mecanum
+ */
+PARAM_DEFINE_FLOAT(RM_WHEEL_TRACK, 0.0f);
+
+/**
+ * Max yaw rate at max throttle
+ *
+ * @unit m/s
+ * @min 0
+ * @group Rover Mecanum
+ */
+PARAM_DEFINE_FLOAT(RM_MAX_THR_YAW_R, 0.0f);
+
+/**
+ * Mission speed gain
+ *
+ * @min -1
+ * @group Rover Mecanum
+ */
+PARAM_DEFINE_FLOAT(RM_MISS_SPD_GAIN, -1.0f);
+
+/**
+ * Course control threshold
+ *
+ * @unit rad
+ * @min 0
+ * @group Rover Mecanum
+ */
+PARAM_DEFINE_FLOAT(RM_COURSE_CTL_TH, 0.17f);
+


### PR DESCRIPTION
## Summary
- define parameters for payload_deliverer
- add rover_ackermann params
- add rover_differential params
- add rover_mecanum params
- include param sources in module builds

## Testing
- `Tools/astyle/check_code_style.sh src/modules/payload_deliverer/payload_deliverer_params.c src/modules/rover_mecanum/rover_mecanum_params.c src/modules/rover_differential/rover_differential_params.c src/modules/rover_ackermann/rover_ackermann_params.c` *(fails: `astyle: command not found`)*