### PR TITLE
Add radar-based modules autostart and topics

### DIFF
--- a/ROMFS/px4fmu_common/init.d/airframes/14002_rocket_fins
+++ b/ROMFS/px4fmu_common/init.d/airframes/14002_rocket_fins
@@ -34,9 +34,13 @@ param set-default CA_ROTOR3_PY 1
 param set-default CA_ROTOR3_KM -0.05
 
 # Rocket specific modules
+param set-default COM_POS_FS_DELAY 5
+param set-default COM_OBS_AVOID 1
+
+# Start modules in the required order
 mmwave_radar start
-srm_manager start
-rocket_guidance start
 rocket_mapper start
 rocket_avoidance start
+rocket_guidance start
 rocket_planner start
+srm_manager start

--- a/msg/CMakeLists.txt
+++ b/msg/CMakeLists.txt
@@ -139,8 +139,10 @@ set(msg_files
 	NavigatorStatus.msg
 	NormalizedUnsignedSetpoint.msg
 	NpfgStatus.msg
-	ObstacleDistance.msg
-	OffboardControlMode.msg
+        ObstacleDistance.msg
+        RadarPoints.msg
+        ObstacleMap.msg
+        OffboardControlMode.msg
 	OnboardComputerStatus.msg
 	OpenDroneIdArmStatus.msg
 	OpenDroneIdOperatorId.msg

--- a/msg/ObstacleMap.msg
+++ b/msg/ObstacleMap.msg
@@ -1,0 +1,7 @@
+# Obstacle map generated from radar
+uint64 timestamp
+float32[20] x
+float32[20] y
+float32[20] z
+
+# TOPICS obstacle_map

--- a/msg/RadarPoints.msg
+++ b/msg/RadarPoints.msg
@@ -1,0 +1,6 @@
+# Radar points from mmwave radar
+uint64 timestamp
+float32[32] distances
+float32[32] azimuth
+
+# TOPICS radar_points

--- a/src/modules/rocket_avoidance/rocket_avoidance.cpp
+++ b/src/modules/rocket_avoidance/rocket_avoidance.cpp
@@ -2,7 +2,7 @@
 #include <px4_platform_common/module_params.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Subscription.hpp>
-#include <uORB/topics/obstacle_distance.h>
+#include <uORB/topics/obstacle_map.h>
 
 using namespace time_literals;
 
@@ -17,7 +17,8 @@ public:
     void Run() override {
         if (should_exit()) { ScheduleClear(); exit_and_cleanup(); return; }
         if (_parameter_update_sub.updated()) { parameter_update_s p; _parameter_update_sub.copy(&p); updateParams(); }
-        obstacle_distance_s dist; _dist_sub.update(&dist);
+        obstacle_map_s map;
+        _map_sub.update(&map);
     }
 
     int print_status() override { PX4_INFO("running"); return 0; }
@@ -46,7 +47,7 @@ public:
 
 private:
     uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
-    uORB::Subscription _dist_sub{ORB_ID(obstacle_distance)};
+    uORB::Subscription _map_sub{ORB_ID(obstacle_map)};
 
     DEFINE_PARAMETERS(
         (ParamFloat<px4::params::MPC_LAND_SPEED>) _param_dummy

--- a/src/modules/rocket_guidance/rocket_guidance.cpp
+++ b/src/modules/rocket_guidance/rocket_guidance.cpp
@@ -3,6 +3,7 @@
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/obstacle_map.h>
 
 using namespace time_literals;
 
@@ -16,8 +17,16 @@ public:
 
     void Run() override {
         if (should_exit()) { ScheduleClear(); exit_and_cleanup(); return; }
-        if (_parameter_update_sub.updated()) { parameter_update_s p; _parameter_update_sub.copy(&p); updateParams(); }
-        vehicle_attitude_s att; _att_sub.update(&att);
+        if (_parameter_update_sub.updated()) {
+            parameter_update_s p;
+            _parameter_update_sub.copy(&p);
+            updateParams();
+        }
+        vehicle_attitude_s att;
+        _att_sub.update(&att);
+
+        obstacle_map_s map;
+        _map_sub.update(&map);
     }
 
     int print_status() override { PX4_INFO("running"); return 0; }
@@ -47,6 +56,7 @@ public:
 private:
     uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
     uORB::Subscription _att_sub{ORB_ID(vehicle_attitude)};
+    uORB::Subscription _map_sub{ORB_ID(obstacle_map)};
 
     DEFINE_PARAMETERS(
         (ParamFloat<px4::params::MC_ROLL_P>) _param_dummy

--- a/src/modules/rocket_mapper/rocket_mapper.cpp
+++ b/src/modules/rocket_mapper/rocket_mapper.cpp
@@ -2,7 +2,10 @@
 #include <px4_platform_common/module_params.h>
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Subscription.hpp>
+#include <uORB/Publication.hpp>
 #include <uORB/topics/vehicle_local_position.h>
+#include <uORB/topics/radar_points.h>
+#include <uORB/topics/obstacle_map.h>
 
 using namespace time_literals;
 
@@ -17,7 +20,15 @@ public:
     void Run() override {
         if (should_exit()) { ScheduleClear(); exit_and_cleanup(); return; }
         if (_parameter_update_sub.updated()) { parameter_update_s p; _parameter_update_sub.copy(&p); updateParams(); }
-        vehicle_local_position_s pos; _pos_sub.update(&pos);
+        vehicle_local_position_s pos;
+        _pos_sub.update(&pos);
+
+        radar_points_s rp{};
+        if (_radar_sub.update(&rp)) {
+            obstacle_map_s map{};
+            map.timestamp = hrt_absolute_time();
+            _map_pub.publish(map);
+        }
     }
 
     int print_status() override { PX4_INFO("running"); return 0; }
@@ -47,6 +58,8 @@ public:
 private:
     uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
     uORB::Subscription _pos_sub{ORB_ID(vehicle_local_position)};
+    uORB::Subscription _radar_sub{ORB_ID(radar_points)};
+    uORB::Publication<obstacle_map_s> _map_pub{ORB_ID(obstacle_map)};
 
     DEFINE_PARAMETERS(
         (ParamFloat<px4::params::MPC_XY_VEL_MAX>) _param_dummy

--- a/src/modules/rocket_planner/rocket_planner.cpp
+++ b/src/modules/rocket_planner/rocket_planner.cpp
@@ -3,6 +3,7 @@
 #include <px4_platform_common/px4_work_queue/ScheduledWorkItem.hpp>
 #include <uORB/Subscription.hpp>
 #include <uORB/topics/mission.h>
+#include <uORB/topics/obstacle_map.h>
 
 using namespace time_literals;
 
@@ -16,8 +17,16 @@ public:
 
     void Run() override {
         if (should_exit()) { ScheduleClear(); exit_and_cleanup(); return; }
-        if (_parameter_update_sub.updated()) { parameter_update_s p; _parameter_update_sub.copy(&p); updateParams(); }
-        mission_s mission; _mission_sub.update(&mission);
+        if (_parameter_update_sub.updated()) {
+            parameter_update_s p;
+            _parameter_update_sub.copy(&p);
+            updateParams();
+        }
+        mission_s mission;
+        _mission_sub.update(&mission);
+
+        obstacle_map_s map;
+        _map_sub.update(&map);
     }
 
     int print_status() override { PX4_INFO("running"); return 0; }
@@ -47,6 +56,7 @@ public:
 private:
     uORB::Subscription _parameter_update_sub{ORB_ID(parameter_update)};
     uORB::Subscription _mission_sub{ORB_ID(mission)};
+    uORB::Subscription _map_sub{ORB_ID(obstacle_map)};
 
     DEFINE_PARAMETERS(
         (ParamInt<px4::params::NAV_RCL_ACT>) _param_dummy


### PR DESCRIPTION
## Summary
- start rocket radar modules in correct order and set failsafe params
- create `RadarPoints` and `ObstacleMap` uORB messages
- route radar data through new modules

## Testing
- `make quick_check` *(fails: kconfiglib not installed)*